### PR TITLE
Turn off default-features for image dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,16 @@ repository = "https://github.com/TheHellBox/x11-screenshot-rs"
 description = "Screenshots with x11"
 
 [dependencies]
-image = "0.16.0"
 libc="0.2.33"
+
+[dependencies.image]
+version = "0.16.0"
+default-features = false
 
 [dependencies.x11]
 version = "2.16.0"
 features = ["xlib"]
+
+[[example]]
+name = "basic"
+required-features = ["image/png_codec"]


### PR DESCRIPTION
This way, users of the crate don't have to compile a lot of unnecessary
image codecs.

For example, my use case is to simply take a screenshot, and check the color values of some pixels.
No image codecs are necessary.