### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ repository = "https://github.com/TheHellBox/x11-screenshot-rs"
 description = "Screenshots with x11"
 
 [dependencies.image]
-version = "0.21.0"
+version = "0.23.5"
 default-features = false
 
 [dependencies.x11]
-version = "2.16.0"
+version = "2.18.2"
 features = ["xlib"]
 
 [[example]]
 name = "basic"
-required-features = ["image/png_codec"]
+required-features = ["image/ico"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ impl Screen {
 
             for pix in image_buffer.pixels_mut() {
                 let bgr = bgr_iter.next().unwrap();
-                pix.data = [bgr.r, bgr.g, bgr.b];
+                pix.0 = [bgr.r, bgr.g, bgr.b];
             }
 
             unsafe {


### PR DESCRIPTION
The version of `image` currently being used has been yanked and has had several breaking changes since, this pull request just updates the image and x11 crates and fixes any errors with the update.