### PR TITLE
Bump deps. Cargo fmt. Rust 2018.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,10 @@ keywords = ["X11", "screen", "screenshot", "capture"]
 license = "MIT"
 repository = "https://github.com/TheHellBox/x11-screenshot-rs"
 description = "Screenshots with x11"
+edition = "2018"
 
 [dependencies.image]
-version = "0.23.5"
+version = "0.23.12"
 default-features = false
 
 [dependencies.x11]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,7 @@
 
 #![warn(missing_docs)]
 
-extern crate image;
-extern crate x11;
-use self::image::RgbImage;
+use image::RgbImage;
 use std::{ptr, slice};
 use x11::xlib;
 /// A handle to an X11 screen.
@@ -55,18 +53,8 @@ impl Screen {
     ///
     /// See the documentation of the `image` crate on how to use `RgbImage`.
     pub fn capture_area(&self, w: u32, h: u32, x: i32, y: i32) -> Option<RgbImage> {
-        let img = unsafe {
-            xlib::XGetImage(
-                self.display,
-                self.window,
-                x,
-                y,
-                w,
-                h,
-                !1,
-                xlib::ZPixmap,
-            )
-        };
+        let img =
+            unsafe { xlib::XGetImage(self.display, self.window, x, y, w, h, !1, xlib::ZPixmap) };
 
         if !img.is_null() {
             let image = unsafe { &mut *img };


### PR DESCRIPTION
* Bumped dependencies
* Switched to rust 2018
* Removed `extern`s 
* Cargo fmt